### PR TITLE
Bug/safari desktop width

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,14 +5,14 @@
 @import './styling/navigation.scss';
 @import './styling/resources.scss';
 
-@media (max-width: 500px) {
+@media (max-width: 505px) {
   .App { 
     width: 100%;
    }
   .Wipe { display: none; }
 }
 
-@media (min-width: 501px) {
+@media (min-width: 506px) {
   // for desktop wipe
   .Wipe { 
     font-size: 7vh;

--- a/src/partials/Responsive.js
+++ b/src/partials/Responsive.js
@@ -4,7 +4,7 @@ import MediaQuery from "react-responsive";
 const Responsive = () => {
   return (
     <div className="Wipe">
-      <MediaQuery minWidth={501}>
+      <MediaQuery minWidth={505}>
         <br />
         <span role="img" aria-label="Grimacing Face">
           😬

--- a/src/styling/activity/filters.scss
+++ b/src/styling/activity/filters.scss
@@ -99,7 +99,7 @@
 
         //removes background image onfocus
         .search-bar:focus {
-          background-image: url();
+          background-image:none;
         }
 
         .geo-location {


### PR DESCRIPTION
Fixes # issue with Safari browser of minimum window width of 503px. Reset responsive wipeout and min/max media queries to 505px which fixes the problem.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
Tested locally - no side effects observed.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts